### PR TITLE
feat: insert buffer 기반 granule flush 경로 추가

### DIFF
--- a/.github/workflows/compile_check.yml
+++ b/.github/workflows/compile_check.yml
@@ -1,31 +1,62 @@
-name: Compile Check (Cargo Build)
+name: Compile Check
 
 on:
   pull_request:
-
-env:
-  CARGO_TERM_COLOR: always
+  push:
+    branches:
+      - main
+      - master
 
 jobs:
-  build_and_test:
-    name: Rust project - latest
-    strategy:
-      max-parallel: 3
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain:
-          - stable
-    runs-on: ${{ matrix.os }}
+  ubuntu-pgrx:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      DEBIAN_FRONTEND: noninteractive
+      PGRX_HOME: ${{ github.workspace }}/.pgrx
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
 
-      - run: cargo build
+      - name: Configure PostgreSQL APT repository
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl ca-certificates gnupg postgresql-common
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+          sudo apt-get update
+
+      - name: Install PostgreSQL and clang dependencies
+        run: |
+          sudo apt-get install -y \
+            build-essential \
+            clang \
+            llvm-dev \
+            libclang-dev \
+            pkg-config \
+            postgresql-18 \
+            postgresql-server-dev-18
+
+      - name: Install cargo-pgrx
+        run: cargo install --locked cargo-pgrx --version 0.17.0
+
+      - name: Initialize pgrx
+        run: cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config
+
+      - name: Compile extension
+        run: cargo check --features pg18
+
+      - name: Generate extension schema
+        run: cargo pgrx schema --features pg18 > /tmp/pghouse.sql
+
+      - name: Run unit tests
+        run: cargo test --lib core::scan::tests --features "pg18 pg_test" --no-default-features

--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -9,7 +9,8 @@
 - `CREATE TABLE ... USING pghouse` 가능
 - 실제 table AM read/write 엔진은 아직 heap delegate
 - 별도 sidecar metadata와 granule 파일 저장 경로를 사용
-- background maintenance가 mutation을 흡수하고 granule snapshot을 재작성
+- insert는 file-backed buffer에 먼저 적재되고, background maintenance가 granule로 flush
+- update/delete는 비동기 mutation으로 흡수한 뒤 granule snapshot을 재작성
 
 ## 상위 구조
 
@@ -148,11 +149,12 @@ maintenance orchestration.
 흐름:
 
 1. candidate table 조회
-2. `pending_rows` 적용
-3. dirty row / merge queue 검사
-4. live rows 조회
-5. `core::snapshot`으로 granule write request 생성
-6. `pg::storage` writer로 파일 및 metadata 반영
+2. ready insert buffer flush
+3. `pending_rows` 적용
+4. dirty row / merge queue 검사
+5. live rows 조회
+6. `core::snapshot`으로 granule write request 생성
+7. `pg::storage` writer로 파일 및 metadata 반영
 
 핵심 원칙:
 
@@ -164,17 +166,41 @@ maintenance orchestration.
 현재 write path는 직접 table AM write가 아니라 sidecar pipeline이다.
 
 1. 사용자가 `USING pghouse` 테이블에 DML 수행
-2. trigger `pghouse.capture_dml()`가 `pghouse.pending_rows`에 mutation 적재
-3. maintenance worker가 pending mutation을 `pghouse.row_versions`에 반영
-4. dirty/live row를 PK 순서로 읽음
-5. granule 단위로 column chunk 생성 및 압축
-6. 파일을 `storage_root` 아래에 기록
-7. granule locator metadata를 `pghouse.granules`에 기록하고, column chunk 상세는 granule별 `manifest.json`에 기록
+2. trigger `pghouse.capture_dml()`가 `INSERT`는 `pghouse_stage_insert()`로 보내고, `UPDATE/DELETE`는 `pghouse.pending_rows`에 적재
+3. `INSERT`는 `pghouse.insert_buffers` 메타와 `incoming/*.jsonl` spool file에 먼저 쌓임
+4. maintenance worker가 sealed/timeout buffer를 읽어 granule 단위로 압축해 append
+5. flush된 row는 `pghouse.row_versions`에도 upsert되어 이후 merge snapshot의 기반이 됨
+6. `UPDATE/DELETE`는 maintenance worker가 `pghouse.row_versions`에 반영
+7. dirty/live row를 PK 순서로 읽어 full rewrite가 필요하면 granule snapshot을 재작성
+8. granule locator metadata를 `pghouse.granules`에 기록하고, column chunk 상세는 granule별 `manifest.json`에 기록
 
 즉 현재는:
 
 - base row storage: heap
 - analytics sidecar storage: pghouse file-backed granules + per-granule manifest
+
+## Insert Buffer 모델
+
+ClickHouse의 `Squashing` + `AsynchronousInsertQueue`와 비슷하게, `pghouse`는 insert를 바로 granule로 쓰지 않는다.
+
+- 짧은 수명 버퍼: 트리거 호출 단위에서 JSON row를 spool file에 append
+- flush 조건:
+  - `insert_buffer_rows`
+  - `insert_buffer_bytes`
+  - `insert_flush_ms`
+- flush 결과:
+  - row들을 PK 기준 정렬
+  - `granule_rows` 기준으로 분할
+  - 컬럼별 chunk 압축
+  - granule append
+
+이 구조의 의도는 다음과 같다.
+
+- 작은 insert를 바로 granule로 쪼개지 않기
+- flush 전까지는 file-backed buffer에서 흡수하기
+- merge worker가 insert path 전체를 full rewrite로 떠안지 않게 하기
+
+현재 `pghouse_scan_rows(...)`는 committed granule뿐 아니라 아직 flush되지 않은 visible insert buffer도 함께 읽는다.
 
 ## `extension_sql!` 사용 기준
 

--- a/src/core/file_layout.rs
+++ b/src/core/file_layout.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Serialize, de::DeserializeOwned};
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
 pub(crate) fn reset_storage_root(storage_root: &str) -> Result<()> {
@@ -122,6 +122,53 @@ pub(crate) fn manifest_file_name() -> &'static str {
 
 pub(crate) fn manifest_relative_path(generation: i64) -> PathBuf {
     PathBuf::from(granule_dir_name(generation)).join(manifest_file_name())
+}
+
+pub(crate) fn incoming_dir_name() -> &'static str {
+    "incoming"
+}
+
+pub(crate) fn append_json_line<T: Serialize>(path: &Path, value: &T) -> Result<usize> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
+    }
+
+    let mut payload = serde_json::to_vec(value)
+        .with_context(|| format!("failed to serialize json line {}", path.display()))?;
+    payload.push(b'\n');
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open append file {}", path.display()))?;
+    file.write_all(&payload)
+        .with_context(|| format!("failed to append file {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync append file {}", path.display()))?;
+
+    Ok(payload.len())
+}
+
+pub(crate) fn read_json_lines<T: DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("failed to open jsonl file {}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut values = Vec::new();
+    for line in reader.lines() {
+        let line =
+            line.with_context(|| format!("failed to read jsonl line from {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        values.push(serde_json::from_str::<T>(&line).with_context(|| {
+            format!("failed to decode jsonl line from {}", path.display())
+        })?);
+    }
+
+    Ok(values)
 }
 
 fn parse_generation_dir_name(name: &str) -> Option<i64> {

--- a/src/core/interface.rs
+++ b/src/core/interface.rs
@@ -1,3 +1,4 @@
+use crate::core::pk::PkCompareMode;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -8,6 +9,7 @@ pub struct TableDescriptor {
     pub schema_name: String,
     pub table_name: String,
     pub pk_column: String,
+    pub pk_compare: PkCompareMode,
     pub granule_rows: usize,
     pub compression: String,
     pub storage_root: String,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod codec;
 pub mod file_layout;
 pub mod interface;
+pub mod pk;
 pub mod scan;
 pub mod snapshot;

--- a/src/core/pk.rs
+++ b/src/core/pk.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PkCompareMode {
+    Lexical,
+    I64,
+}
+
+impl PkCompareMode {
+    pub(crate) fn from_sql_label(value: &str) -> Self {
+        match value {
+            "i64" => Self::I64,
+            _ => Self::Lexical,
+        }
+    }
+
+    pub(crate) fn as_sql_label(self) -> &'static str {
+        match self {
+            Self::Lexical => "lexical",
+            Self::I64 => "i64",
+        }
+    }
+}
+
+pub(crate) fn compare_pk_text(mode: PkCompareMode, left: &str, right: &str) -> Ordering {
+    match mode {
+        PkCompareMode::Lexical => left.cmp(right),
+        PkCompareMode::I64 => match (left.parse::<i64>(), right.parse::<i64>()) {
+            (Ok(left_value), Ok(right_value)) => {
+                left_value.cmp(&right_value).then_with(|| left.cmp(right))
+            }
+            (Ok(_), Err(_)) => Ordering::Less,
+            (Err(_), Ok(_)) => Ordering::Greater,
+            (Err(_), Err(_)) => left.cmp(right),
+        },
+    }
+}
+
+pub(crate) fn compare_optional_pk_text(
+    mode: PkCompareMode,
+    left: Option<&str>,
+    right: Option<&str>,
+) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => compare_pk_text(mode, left, right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+pub(crate) fn pk_matches_bounds(
+    mode: PkCompareMode,
+    value: Option<&str>,
+    pk_min: Option<&str>,
+    pk_max: Option<&str>,
+) -> bool {
+    let Some(value) = value else {
+        return pk_min.is_none() && pk_max.is_none();
+    };
+
+    if pk_min.is_some_and(|bound| compare_pk_text(mode, value, bound).is_lt()) {
+        return false;
+    }
+
+    if pk_max.is_some_and(|bound| compare_pk_text(mode, value, bound).is_gt()) {
+        return false;
+    }
+
+    true
+}
+
+pub(crate) fn granule_overlaps(
+    mode: PkCompareMode,
+    granule_min: Option<&str>,
+    granule_max: Option<&str>,
+    pk_min: Option<&str>,
+    pk_max: Option<&str>,
+) -> bool {
+    if let Some(pk_min) = pk_min
+        && granule_max.is_some_and(|value| compare_pk_text(mode, value, pk_min).is_lt())
+    {
+        return false;
+    }
+
+    if let Some(pk_max) = pk_max
+        && granule_min.is_some_and(|value| compare_pk_text(mode, value, pk_max).is_gt())
+    {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PkCompareMode, compare_pk_text, granule_overlaps, pk_matches_bounds};
+    use std::cmp::Ordering;
+
+    #[test]
+    fn i64_mode_sorts_numeric_text_numerically() {
+        assert_eq!(compare_pk_text(PkCompareMode::I64, "2", "10"), Ordering::Less);
+        assert_eq!(
+            compare_pk_text(PkCompareMode::Lexical, "2", "10"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn i64_mode_uses_numeric_bounds() {
+        assert!(pk_matches_bounds(
+            PkCompareMode::I64,
+            Some("10"),
+            Some("2"),
+            Some("20")
+        ));
+        assert!(!pk_matches_bounds(
+            PkCompareMode::I64,
+            Some("10"),
+            Some("11"),
+            Some("20")
+        ));
+    }
+
+    #[test]
+    fn i64_mode_prunes_non_overlapping_numeric_granules() {
+        assert!(!granule_overlaps(
+            PkCompareMode::I64,
+            Some("10"),
+            Some("20"),
+            Some("2"),
+            Some("9")
+        ));
+    }
+}

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -3,6 +3,12 @@ use anyhow::{Result, bail};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 
+#[derive(Debug, Clone)]
+pub(crate) struct MaterializedRow {
+    pub(crate) pk_text: Option<String>,
+    pub(crate) row: Value,
+}
+
 pub(crate) fn build_scan_plan(
     request: &ScanRequest,
     available_granules: &[GranuleRef],
@@ -51,7 +57,10 @@ pub(crate) fn build_scan_plan(
     })
 }
 
-pub(crate) fn materialize_rows(plan: &ScanPlan, batches: &[ScanBatch]) -> Result<Vec<Value>> {
+pub(crate) fn materialize_row_entries(
+    plan: &ScanPlan,
+    batches: &[ScanBatch],
+) -> Result<Vec<MaterializedRow>> {
     let mut rows = Vec::new();
     let projected_columns = plan
         .projection
@@ -95,7 +104,10 @@ pub(crate) fn materialize_rows(plan: &ScanPlan, batches: &[ScanBatch]) -> Result
                 row.insert(column_descriptor.name.clone(), value.clone());
             }
 
-            rows.push(Value::Object(row));
+            rows.push(MaterializedRow {
+                pk_text: pk_value,
+                row: Value::Object(row),
+            });
             if let Some(limit) = plan.limit
                 && rows.len() >= limit
             {
@@ -149,17 +161,13 @@ fn batch_row_count(batch: &ScanBatch) -> Result<usize> {
 }
 
 fn load_pk_value(plan: &ScanPlan, batch: &ScanBatch, row_index: usize) -> Result<Option<String>> {
-    if plan.pk_min.is_none() && plan.pk_max.is_none() {
-        return Ok(None);
-    }
-
     let pk_column = batch
         .columns
         .iter()
         .find(|column| column.column.name == plan.table.pk_column)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "scan batch for generation {} is missing PK column {} required for filtering",
+                "scan batch for generation {} is missing PK column {}",
                 batch.granule.generation,
                 plan.table.pk_column
             )
@@ -204,7 +212,7 @@ fn value_to_pk_text(value: &Value) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_scan_plan, materialize_rows};
+    use super::{build_scan_plan, materialize_row_entries};
     use crate::core::interface::{
         ColumnDescriptor, ColumnVector, GranuleRef, ScanBatch, ScanRequest, TableDescriptor,
     };
@@ -296,7 +304,7 @@ mod tests {
             }],
         )
         .unwrap();
-        let rows = materialize_rows(
+        let rows = materialize_row_entries(
             &plan,
             &[ScanBatch {
                 granule: plan.granules[0].clone(),
@@ -320,6 +328,61 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(rows, vec![json!({"payload": {"a": 2}})]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].row, json!({"payload": {"a": 2}}));
+    }
+
+    #[test]
+    fn materialize_row_entries_keeps_pk_outside_projection() {
+        let request = ScanRequest {
+            table: test_table(),
+            projection: vec![ColumnDescriptor {
+                ordinal: 2,
+                name: "payload".to_string(),
+            }],
+            pk_min: None,
+            pk_max: None,
+            limit: None,
+            snapshot_generation: None,
+        };
+        let plan = build_scan_plan(
+            &request,
+            &[GranuleRef {
+                table_oid: 1,
+                generation: 1,
+                row_count: 1,
+                pk_min: Some("1".to_string()),
+                pk_max: Some("1".to_string()),
+                manifest_path: "g00000000000000000001/manifest.json".to_string(),
+            }],
+        )
+        .unwrap();
+        let rows = materialize_row_entries(
+            &plan,
+            &[ScanBatch {
+                granule: plan.granules[0].clone(),
+                columns: vec![
+                    ColumnVector {
+                        column: ColumnDescriptor {
+                            ordinal: 1,
+                            name: "id".to_string(),
+                        },
+                        values: vec![json!(1)],
+                    },
+                    ColumnVector {
+                        column: ColumnDescriptor {
+                            ordinal: 2,
+                            name: "payload".to_string(),
+                        },
+                        values: vec![json!({"a": 1})],
+                    },
+                ],
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pk_text.as_deref(), Some("1"));
+        assert_eq!(rows[0].row, json!({"payload": {"a": 1}}));
     }
 }

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -1,4 +1,5 @@
 use crate::core::interface::{GranuleRef, ScanBatch, ScanPlan, ScanRequest};
+use crate::core::pk::{granule_overlaps, pk_matches_bounds};
 use anyhow::{Result, bail};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
@@ -24,7 +25,9 @@ pub(crate) fn build_scan_plan(
         }
 
         if !granule_overlaps(
-            granule,
+            request.table.pk_compare,
+            granule.pk_min.as_deref(),
+            granule.pk_max.as_deref(),
             request.pk_min.as_deref(),
             request.pk_max.as_deref(),
         ) {
@@ -73,6 +76,7 @@ pub(crate) fn materialize_row_entries(
         for row_index in 0..row_count {
             let pk_value = load_pk_value(plan, batch, row_index)?;
             if !pk_matches_bounds(
+                plan.table.pk_compare,
                 pk_value.as_deref(),
                 plan.pk_min.as_deref(),
                 plan.pk_max.as_deref(),
@@ -119,28 +123,6 @@ pub(crate) fn materialize_row_entries(
     Ok(rows)
 }
 
-fn granule_overlaps(granule: &GranuleRef, pk_min: Option<&str>, pk_max: Option<&str>) -> bool {
-    if let Some(pk_min) = pk_min
-        && granule
-            .pk_max
-            .as_deref()
-            .is_some_and(|value| value < pk_min)
-    {
-        return false;
-    }
-
-    if let Some(pk_max) = pk_max
-        && granule
-            .pk_min
-            .as_deref()
-            .is_some_and(|value| value > pk_max)
-    {
-        return false;
-    }
-
-    true
-}
-
 fn batch_row_count(batch: &ScanBatch) -> Result<usize> {
     let mut row_count = None;
     for column in &batch.columns {
@@ -184,22 +166,6 @@ fn load_pk_value(plan: &ScanPlan, batch: &ScanBatch, row_index: usize) -> Result
     Ok(value_to_pk_text(value))
 }
 
-fn pk_matches_bounds(value: Option<&str>, pk_min: Option<&str>, pk_max: Option<&str>) -> bool {
-    let Some(value) = value else {
-        return pk_min.is_none() && pk_max.is_none();
-    };
-
-    if pk_min.is_some_and(|bound| value < bound) {
-        return false;
-    }
-
-    if pk_max.is_some_and(|bound| value > bound) {
-        return false;
-    }
-
-    true
-}
-
 fn value_to_pk_text(value: &Value) -> Option<String> {
     match value {
         Value::Null => None,
@@ -216,6 +182,7 @@ mod tests {
     use crate::core::interface::{
         ColumnDescriptor, ColumnVector, GranuleRef, ScanBatch, ScanRequest, TableDescriptor,
     };
+    use crate::core::pk::PkCompareMode;
     use serde_json::json;
 
     fn test_table() -> TableDescriptor {
@@ -224,6 +191,7 @@ mod tests {
             schema_name: "public".to_string(),
             table_name: "events".to_string(),
             pk_column: "id".to_string(),
+            pk_compare: PkCompareMode::Lexical,
             granule_rows: 2,
             compression: "zstd".to_string(),
             storage_root: "/tmp/pghouse".to_string(),

--- a/src/pg/api.rs
+++ b/src/pg/api.rs
@@ -1,13 +1,19 @@
+use crate::core::file_layout::incoming_dir_name;
 use crate::core::interface::ScanRequest;
 use crate::pg::catalog::{
-    enqueue_backfill, enqueue_merge, install_capture_trigger, load_table_config, relation_identity,
-    reset_sidecar_state, resolve_projection, upsert_table_config,
+    create_insert_buffer, enqueue_backfill, enqueue_merge, install_capture_trigger,
+    load_active_insert_buffer, load_table_config, relation_identity, reset_sidecar_state,
+    resolve_projection, update_insert_buffer_after_append, upsert_table_config,
 };
 use crate::pg::scan::{execute_scan, plan_scan};
-use crate::pg::storage::{reset_table_storage, resolve_storage_root};
-use anyhow::{Result, bail};
+use crate::pg::storage::{
+    insert_buffer_absolute_path, reset_table_storage, resolve_storage_root,
+};
+use anyhow::{Result, anyhow, bail};
 use pgrx::JsonB;
+use pgrx::datum::JsonB as DatumJsonB;
 use pgrx::prelude::*;
+use serde_json::Value;
 use serde_json::json;
 
 #[pg_extern]
@@ -17,6 +23,9 @@ fn pghouse_register_table(
     granule_rows: default!(i32, 8192),
     compression: default!(String, "'zstd'"),
     storage_path: default!(String, "''"),
+    insert_buffer_rows: default!(i32, 8192),
+    insert_buffer_bytes: default!(i64, 8_388_608),
+    insert_flush_ms: default!(i32, 200),
     backfill_existing: default!(bool, true),
 ) -> JsonB {
     let response = register_table(
@@ -25,6 +34,9 @@ fn pghouse_register_table(
         granule_rows,
         &compression,
         &storage_path,
+        insert_buffer_rows,
+        insert_buffer_bytes,
+        insert_flush_ms,
         backfill_existing,
     )
     .unwrap_or_else(|error| error!("pghouse_register_table failed: {error:#}"));
@@ -35,6 +47,12 @@ fn pghouse_register_table(
 fn pghouse_schedule_merge(table_name: &str, reason: default!(String, "'manual'")) -> bool {
     schedule_merge(table_name, &reason)
         .unwrap_or_else(|error| error!("pghouse_schedule_merge failed: {error:#}"))
+}
+
+#[pg_extern]
+fn pghouse_stage_insert(table_oid: i64, row_json: DatumJsonB) -> bool {
+    stage_insert(table_oid, row_json.0)
+        .unwrap_or_else(|error| error!("pghouse_stage_insert failed: {error:#}"))
 }
 
 #[pg_extern]
@@ -95,10 +113,22 @@ fn register_table(
     granule_rows: i32,
     compression: &str,
     storage_path: &str,
+    insert_buffer_rows: i32,
+    insert_buffer_bytes: i64,
+    insert_flush_ms: i32,
     backfill_existing: bool,
 ) -> Result<serde_json::Value> {
     if granule_rows <= 0 {
         bail!("granule_rows must be positive");
+    }
+    if insert_buffer_rows <= 0 {
+        bail!("insert_buffer_rows must be positive");
+    }
+    if insert_buffer_bytes <= 0 {
+        bail!("insert_buffer_bytes must be positive");
+    }
+    if insert_flush_ms <= 0 {
+        bail!("insert_flush_ms must be positive");
     }
     if compression != "zstd" {
         bail!("only zstd compression is supported in the current bootstrap");
@@ -112,6 +142,9 @@ fn register_table(
         granule_rows,
         compression,
         &storage_root,
+        insert_buffer_rows,
+        insert_buffer_bytes,
+        insert_flush_ms,
     )?;
     install_capture_trigger(&identity)?;
     reset_sidecar_state(identity.table_oid)?;
@@ -129,6 +162,9 @@ fn register_table(
         "granule_rows": granule_rows,
         "compression": compression,
         "storage_root": storage_root,
+        "insert_buffer_rows": insert_buffer_rows,
+        "insert_buffer_bytes": insert_buffer_bytes,
+        "insert_flush_ms": insert_flush_ms,
         "backfill_existing": backfill_existing,
     }))
 }
@@ -186,4 +222,62 @@ fn normalize_text_arg(value: &str) -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+fn stage_insert(table_oid: i64, row_json: Value) -> Result<bool> {
+    let config = load_table_config(table_oid)?;
+    let pk_text = row_json
+        .get(&config.pk_column)
+        .map(pk_value_to_text)
+        .transpose()?
+        .ok_or_else(|| anyhow!("missing PK column {} in staged insert", config.pk_column))?;
+
+    let mut buffer = if let Some(buffer) = load_active_insert_buffer(table_oid)? {
+        buffer
+    } else {
+        let storage_path = format!(
+            "{}/{}_{}",
+            incoming_dir_name(),
+            config.table_oid,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|value| value.as_nanos())
+                .unwrap_or_default()
+        );
+        create_insert_buffer(table_oid, &storage_path, config.insert_flush_ms)?
+    };
+
+    let absolute_path = insert_buffer_absolute_path(&config.storage_root, &buffer.storage_path);
+    let bytes_written = crate::core::file_layout::append_json_line(
+        &absolute_path,
+        &json!({
+            "pk_text": pk_text,
+            "row_json": row_json,
+        }),
+    )?;
+    let new_row_count = buffer.row_count + 1;
+    let new_byte_count = buffer.byte_count + i64::try_from(bytes_written).unwrap_or(i64::MAX);
+    let should_seal =
+        new_row_count >= config.insert_buffer_rows || new_byte_count >= config.insert_buffer_bytes;
+    update_insert_buffer_after_append(
+        buffer.id,
+        1,
+        i64::try_from(bytes_written).unwrap_or(i64::MAX),
+        should_seal,
+    )?;
+    buffer.row_count = new_row_count;
+    buffer.byte_count = new_byte_count;
+
+    Ok(true)
+}
+
+fn pk_value_to_text(value: &Value) -> Result<String> {
+    let text = match value {
+        Value::Null => bail!("PK value cannot be NULL"),
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        other => serde_json::to_string(other)?,
+    };
+    Ok(text)
 }

--- a/src/pg/api.rs
+++ b/src/pg/api.rs
@@ -1,9 +1,11 @@
 use crate::core::file_layout::incoming_dir_name;
 use crate::core::interface::ScanRequest;
+use crate::core::pk::PkCompareMode;
 use crate::pg::catalog::{
     create_insert_buffer, enqueue_backfill, enqueue_merge, install_capture_trigger,
     load_active_insert_buffer, load_table_config, relation_identity, reset_sidecar_state,
-    resolve_projection, update_insert_buffer_after_append, upsert_table_config,
+    resolve_pk_compare_mode, resolve_projection, update_insert_buffer_after_append,
+    upsert_table_config,
 };
 use crate::pg::scan::{execute_scan, plan_scan};
 use crate::pg::storage::{
@@ -136,9 +138,11 @@ fn register_table(
 
     let identity = relation_identity(table_name)?;
     let storage_root = resolve_storage_root(identity.table_oid, storage_path)?;
+    let pk_compare = resolve_pk_compare_mode(identity.table_oid, pk_column)?;
     upsert_table_config(
         &identity,
         pk_column,
+        pk_compare,
         granule_rows,
         compression,
         &storage_root,
@@ -159,6 +163,10 @@ fn register_table(
         "schema": identity.schema_name,
         "table": identity.relname,
         "pk_column": pk_column,
+        "pk_compare": match pk_compare {
+            PkCompareMode::Lexical => "lexical",
+            PkCompareMode::I64 => "i64",
+        },
         "granule_rows": granule_rows,
         "compression": compression,
         "storage_root": storage_root,

--- a/src/pg/catalog.rs
+++ b/src/pg/catalog.rs
@@ -21,6 +21,9 @@ pub(crate) struct TableConfig {
     pub(crate) granule_rows: i32,
     pub(crate) compression: String,
     pub(crate) storage_root: String,
+    pub(crate) insert_buffer_rows: i32,
+    pub(crate) insert_buffer_bytes: i64,
+    pub(crate) insert_flush_ms: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -41,6 +44,14 @@ pub(crate) struct LiveRow {
 pub(crate) struct ColumnSpec {
     pub(crate) attnum: i32,
     pub(crate) attname: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InsertBuffer {
+    pub(crate) id: i64,
+    pub(crate) storage_path: String,
+    pub(crate) row_count: i32,
+    pub(crate) byte_count: i64,
 }
 
 impl From<&TableConfig> for TableDescriptor {
@@ -68,15 +79,33 @@ pgrx::extension_sql!(
         granule_rows integer NOT NULL CHECK (granule_rows > 0),
         compression text NOT NULL CHECK (compression IN ('zstd')),
         storage_root text NOT NULL,
+        insert_buffer_rows integer NOT NULL CHECK (insert_buffer_rows > 0),
+        insert_buffer_bytes bigint NOT NULL CHECK (insert_buffer_bytes > 0),
+        insert_flush_ms integer NOT NULL CHECK (insert_flush_ms > 0),
         registered_at timestamptz NOT NULL DEFAULT now(),
         last_flush_at timestamptz,
         last_merge_at timestamptz
     );
 
+    CREATE TABLE pghouse.insert_buffers (
+        id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        table_oid oid NOT NULL REFERENCES pghouse.tables(table_oid) ON DELETE CASCADE,
+        storage_path text NOT NULL,
+        row_count integer NOT NULL DEFAULT 0,
+        byte_count bigint NOT NULL DEFAULT 0,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        flush_after timestamptz NOT NULL,
+        sealed_at timestamptz,
+        flush_started_at timestamptz,
+        flushed_at timestamptz
+    );
+    CREATE INDEX pghouse_insert_buffers_ready_idx
+        ON pghouse.insert_buffers (table_oid, flushed_at, flush_started_at, flush_after, id);
+
     CREATE TABLE pghouse.pending_rows (
         id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
         table_oid oid NOT NULL REFERENCES pghouse.tables(table_oid) ON DELETE CASCADE,
-        op text NOT NULL CHECK (op IN ('insert', 'update', 'delete')),
+        op text NOT NULL CHECK (op IN ('update', 'delete')),
         pk_text text NOT NULL,
         row_json jsonb,
         queued_at timestamptz NOT NULL DEFAULT now(),
@@ -155,31 +184,23 @@ pgrx::extension_sql!(
             visible_at := now() + interval '1 second';
         END IF;
 
-        INSERT INTO pghouse.pending_rows (
-            table_oid,
-            op,
-            pk_text,
-            row_json,
-            apply_after
-        )
-        VALUES (
-            TG_RELID,
-            lower(TG_OP),
-            pk_value,
-            CASE WHEN TG_OP = 'DELETE' THEN NULL ELSE payload END,
-            visible_at
-        );
-
-        IF TG_OP IN ('UPDATE', 'DELETE') THEN
-            INSERT INTO pghouse.merge_queue (table_oid, reason)
-            VALUES (TG_RELID, lower(TG_OP) || '_captured');
+        IF TG_OP = 'INSERT' THEN
+            PERFORM pghouse_stage_insert(TG_RELID::bigint, payload);
+            RETURN NEW;
         END IF;
+
+        INSERT INTO pghouse.pending_rows (table_oid, op, pk_text, row_json, apply_after)
+        VALUES (TG_RELID, lower(TG_OP), pk_value, CASE WHEN TG_OP = 'DELETE' THEN NULL ELSE payload END, visible_at);
+
+        INSERT INTO pghouse.merge_queue (table_oid, reason)
+        VALUES (TG_RELID, lower(TG_OP) || '_captured');
 
         RETURN COALESCE(NEW, OLD);
     END;
     $$;
     "#,
-    name = "bootstrap_pghouse_catalog"
+    name = "bootstrap_pghouse_catalog",
+    finalize
 );
 
 pub(crate) fn relation_identity(table_name: &str) -> anyhow::Result<RelationIdentity> {
@@ -239,6 +260,9 @@ pub(crate) fn upsert_table_config(
     granule_rows: i32,
     compression: &str,
     storage_root: &str,
+    insert_buffer_rows: i32,
+    insert_buffer_bytes: i64,
+    insert_flush_ms: i32,
 ) -> anyhow::Result<()> {
     let args = [
         DatumWithOid::from(identity.table_oid),
@@ -247,6 +271,9 @@ pub(crate) fn upsert_table_config(
         DatumWithOid::from(granule_rows),
         DatumWithOid::from(compression),
         DatumWithOid::from(storage_root),
+        DatumWithOid::from(insert_buffer_rows),
+        DatumWithOid::from(insert_buffer_bytes),
+        DatumWithOid::from(insert_flush_ms),
     ];
 
     Spi::run_with_args(
@@ -257,7 +284,10 @@ pub(crate) fn upsert_table_config(
             pk_column,
             granule_rows,
             compression,
-            storage_root
+            storage_root,
+            insert_buffer_rows,
+            insert_buffer_bytes,
+            insert_flush_ms
         )
         VALUES (
             $1::oid,
@@ -265,14 +295,20 @@ pub(crate) fn upsert_table_config(
             $3,
             $4,
             $5,
-            $6
+            $6,
+            $7,
+            $8,
+            $9
         )
         ON CONFLICT (table_oid)
         DO UPDATE SET
             pk_column = EXCLUDED.pk_column,
             granule_rows = EXCLUDED.granule_rows,
             compression = EXCLUDED.compression,
-            storage_root = EXCLUDED.storage_root
+            storage_root = EXCLUDED.storage_root,
+            insert_buffer_rows = EXCLUDED.insert_buffer_rows,
+            insert_buffer_bytes = EXCLUDED.insert_buffer_bytes,
+            insert_flush_ms = EXCLUDED.insert_flush_ms
         "#,
         &args,
     )?;
@@ -284,6 +320,7 @@ pub(crate) fn reset_sidecar_state(table_oid: i64) -> anyhow::Result<()> {
     let args = [DatumWithOid::from(table_oid)];
 
     for statement in [
+        "DELETE FROM pghouse.insert_buffers WHERE table_oid = $1::oid",
         "DELETE FROM pghouse.pending_rows WHERE table_oid = $1::oid",
         "DELETE FROM pghouse.row_versions WHERE table_oid = $1::oid",
         "DELETE FROM pghouse.merge_queue WHERE table_oid = $1::oid",
@@ -320,18 +357,14 @@ pub(crate) fn enqueue_backfill(identity: &RelationIdentity, pk_column: &str) -> 
 
     let query = format!(
         r#"
-        INSERT INTO pghouse.pending_rows (table_oid, op, pk_text, row_json)
-        SELECT
-            $1::oid,
-            'insert',
-            to_jsonb(src) ->> $2,
+        SELECT pghouse_stage_insert(
+            $1::bigint,
             to_jsonb(src)
+        )
         FROM {qualified_table} AS src
         "#
     );
     Spi::run_with_args(&query, &args)?;
-
-    enqueue_merge(identity.table_oid, "bootstrap_backfill")?;
 
     Ok(())
 }
@@ -361,7 +394,10 @@ pub(crate) fn load_table_config(table_oid: i64) -> anyhow::Result<TableConfig> {
                 t.pk_column::text AS pk_column,
                 t.granule_rows AS granule_rows,
                 t.compression::text AS compression,
-                t.storage_root::text AS storage_root
+                t.storage_root::text AS storage_root,
+                t.insert_buffer_rows AS insert_buffer_rows,
+                t.insert_buffer_bytes::bigint AS insert_buffer_bytes,
+                t.insert_flush_ms AS insert_flush_ms
             FROM pghouse.tables t
             JOIN pg_class c ON c.oid = t.table_oid
             JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -390,6 +426,15 @@ pub(crate) fn load_table_config(table_oid: i64) -> anyhow::Result<TableConfig> {
                 storage_root: row
                     .get_by_name::<String, _>("storage_root")?
                     .unwrap_or_default(),
+                insert_buffer_rows: row
+                    .get_by_name::<i32, _>("insert_buffer_rows")?
+                    .unwrap_or_default(),
+                insert_buffer_bytes: row
+                    .get_by_name::<i64, _>("insert_buffer_bytes")?
+                    .unwrap_or_default(),
+                insert_flush_ms: row
+                    .get_by_name::<i32, _>("insert_flush_ms")?
+                    .unwrap_or_default(),
             }))
         } else {
             Ok(None)
@@ -407,6 +452,12 @@ pub(crate) fn load_candidate_tables(max_tables: i32) -> anyhow::Result<Vec<i64>>
             r#"
             SELECT DISTINCT table_oid::bigint
             FROM (
+                SELECT table_oid
+                FROM pghouse.insert_buffers
+                WHERE flushed_at IS NULL
+                  AND flush_started_at IS NULL
+                  AND (sealed_at IS NOT NULL OR flush_after <= now())
+                UNION ALL
                 SELECT table_oid
                 FROM pghouse.pending_rows
                 WHERE processed_at IS NULL
@@ -616,6 +667,228 @@ pub(crate) fn load_scan_granules(
     Ok(granules)
 }
 
+pub(crate) fn load_active_insert_buffer(table_oid: i64) -> anyhow::Result<Option<InsertBuffer>> {
+    let args = [DatumWithOid::from(table_oid)];
+
+    let buffer = Spi::connect(|client| -> Result<Option<InsertBuffer>, spi::Error> {
+        let mut rows = client.select(
+            r#"
+            SELECT
+                id::bigint AS id,
+                storage_path::text AS storage_path,
+                row_count AS row_count,
+                byte_count::bigint AS byte_count
+            FROM pghouse.insert_buffers
+            WHERE table_oid = $1::oid
+              AND sealed_at IS NULL
+              AND flushed_at IS NULL
+            ORDER BY id DESC
+            LIMIT 1
+            FOR UPDATE
+            "#,
+            Some(1),
+            &args,
+        )?;
+
+        if let Some(row) = rows.next() {
+            Ok(Some(InsertBuffer {
+                id: row.get_by_name::<i64, _>("id")?.unwrap_or_default(),
+                storage_path: row
+                    .get_by_name::<String, _>("storage_path")?
+                    .unwrap_or_default(),
+                row_count: row.get_by_name::<i32, _>("row_count")?.unwrap_or_default(),
+                byte_count: row.get_by_name::<i64, _>("byte_count")?.unwrap_or_default(),
+            }))
+        } else {
+            Ok(None)
+        }
+    })?;
+
+    Ok(buffer)
+}
+
+pub(crate) fn create_insert_buffer(
+    table_oid: i64,
+    storage_path: &str,
+    flush_after_ms: i32,
+) -> anyhow::Result<InsertBuffer> {
+    let args = [
+        DatumWithOid::from(table_oid),
+        DatumWithOid::from(storage_path),
+        DatumWithOid::from(flush_after_ms),
+    ];
+
+    let id = Spi::get_one_with_args::<i64>(
+        r#"
+        INSERT INTO pghouse.insert_buffers (table_oid, storage_path, flush_after)
+        VALUES (
+            $1::oid,
+            $2,
+            now() + make_interval(secs => 0) + ($3::double precision / 1000.0) * interval '1 second'
+        )
+        RETURNING id::bigint
+        "#,
+        &args,
+    )?
+    .context("failed to create insert buffer")?;
+
+    Ok(InsertBuffer {
+        id,
+        storage_path: storage_path.to_string(),
+        row_count: 0,
+        byte_count: 0,
+    })
+}
+
+pub(crate) fn update_insert_buffer_after_append(
+    buffer_id: i64,
+    row_delta: i32,
+    byte_delta: i64,
+    seal: bool,
+) -> anyhow::Result<()> {
+    let args = [
+        DatumWithOid::from(buffer_id),
+        DatumWithOid::from(row_delta),
+        DatumWithOid::from(byte_delta),
+        DatumWithOid::from(seal),
+    ];
+
+    Spi::run_with_args(
+        r#"
+        UPDATE pghouse.insert_buffers
+        SET row_count = row_count + $2,
+            byte_count = byte_count + $3,
+            sealed_at = CASE
+                WHEN $4 THEN COALESCE(sealed_at, now())
+                ELSE sealed_at
+            END
+        WHERE id = $1
+        "#,
+        &args,
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn claim_ready_insert_buffers(
+    table_oid: i64,
+    limit: i32,
+) -> anyhow::Result<Vec<InsertBuffer>> {
+    let args = [DatumWithOid::from(table_oid), DatumWithOid::from(limit)];
+
+    let buffers = Spi::connect(|client| -> Result<Vec<InsertBuffer>, spi::Error> {
+        let rows = client.select(
+            r#"
+            WITH ready AS (
+                SELECT id
+                FROM pghouse.insert_buffers
+                WHERE table_oid = $1::oid
+                  AND flushed_at IS NULL
+                  AND flush_started_at IS NULL
+                  AND (sealed_at IS NOT NULL OR flush_after <= now())
+                ORDER BY id
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+            ),
+            claimed AS (
+                UPDATE pghouse.insert_buffers b
+                SET flush_started_at = now(),
+                    sealed_at = COALESCE(sealed_at, now())
+                FROM ready
+                WHERE b.id = ready.id
+                RETURNING b.id::bigint AS id,
+                          b.storage_path::text AS storage_path,
+                          b.row_count AS row_count,
+                          b.byte_count::bigint AS byte_count
+            )
+            SELECT * FROM claimed ORDER BY id
+            "#,
+            None,
+            &args,
+        )?;
+
+        let mut buffers = Vec::new();
+        for row in rows {
+            buffers.push(InsertBuffer {
+                id: row.get_by_name::<i64, _>("id")?.unwrap_or_default(),
+                storage_path: row
+                    .get_by_name::<String, _>("storage_path")?
+                    .unwrap_or_default(),
+                row_count: row.get_by_name::<i32, _>("row_count")?.unwrap_or_default(),
+                byte_count: row.get_by_name::<i64, _>("byte_count")?.unwrap_or_default(),
+            });
+        }
+        Ok(buffers)
+    })?;
+
+    Ok(buffers)
+}
+
+pub(crate) fn load_visible_insert_buffers(table_oid: i64) -> anyhow::Result<Vec<InsertBuffer>> {
+    let args = [DatumWithOid::from(table_oid)];
+
+    let buffers = Spi::connect(|client| -> Result<Vec<InsertBuffer>, spi::Error> {
+        let rows = client.select(
+            r#"
+            SELECT
+                id::bigint AS id,
+                storage_path::text AS storage_path,
+                row_count AS row_count,
+                byte_count::bigint AS byte_count
+            FROM pghouse.insert_buffers
+            WHERE table_oid = $1::oid
+              AND flushed_at IS NULL
+              AND flush_started_at IS NULL
+            ORDER BY id
+            "#,
+            None,
+            &args,
+        )?;
+
+        let mut buffers = Vec::new();
+        for row in rows {
+            buffers.push(InsertBuffer {
+                id: row.get_by_name::<i64, _>("id")?.unwrap_or_default(),
+                storage_path: row
+                    .get_by_name::<String, _>("storage_path")?
+                    .unwrap_or_default(),
+                row_count: row.get_by_name::<i32, _>("row_count")?.unwrap_or_default(),
+                byte_count: row.get_by_name::<i64, _>("byte_count")?.unwrap_or_default(),
+            });
+        }
+        Ok(buffers)
+    })?;
+
+    Ok(buffers)
+}
+
+pub(crate) fn mark_insert_buffer_flushed(buffer_id: i64) -> anyhow::Result<()> {
+    let args = [DatumWithOid::from(buffer_id)];
+    Spi::run_with_args(
+        r#"
+        UPDATE pghouse.insert_buffers
+        SET flushed_at = now()
+        WHERE id = $1
+        "#,
+        &args,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn release_insert_buffer_claim(buffer_id: i64) -> anyhow::Result<()> {
+    let args = [DatumWithOid::from(buffer_id)];
+    Spi::run_with_args(
+        r#"
+        UPDATE pghouse.insert_buffers
+        SET flush_started_at = NULL
+        WHERE id = $1
+          AND flushed_at IS NULL
+        "#,
+        &args,
+    )?;
+    Ok(())
+}
+
 pub(crate) fn pending_merge_count(table_oid: i64) -> anyhow::Result<i64> {
     let args = [DatumWithOid::from(table_oid)];
     let count = Spi::get_one_with_args::<i64>(
@@ -755,6 +1028,48 @@ pub(crate) fn apply_mutation(mutation: &PendingMutation, table_oid: i64) -> anyh
     Ok(())
 }
 
+pub(crate) fn upsert_buffered_row_version(
+    table_oid: i64,
+    pk_text: &str,
+    row_json: &str,
+) -> anyhow::Result<()> {
+    let args = [
+        DatumWithOid::from(table_oid),
+        DatumWithOid::from(pk_text),
+        DatumWithOid::from(row_json),
+    ];
+
+    Spi::run_with_args(
+        r#"
+        INSERT INTO pghouse.row_versions (
+            table_oid,
+            pk_text,
+            row_json,
+            deleted,
+            dirty,
+            last_mutation_id
+        )
+        VALUES (
+            $1::oid,
+            $2,
+            $3::jsonb,
+            false,
+            false,
+            0
+        )
+        ON CONFLICT (table_oid, pk_text)
+        DO UPDATE SET
+            row_json = EXCLUDED.row_json,
+            deleted = false,
+            dirty = false,
+            updated_at = now()
+        "#,
+        &args,
+    )?;
+
+    Ok(())
+}
+
 pub(crate) fn insert_granule(
     table_oid: i64,
     generation: i64,
@@ -809,6 +1124,19 @@ pub(crate) fn mark_merge_success(table_oid: i64) -> anyhow::Result<()> {
         Spi::run_with_args(statement, &args)?;
     }
 
+    Ok(())
+}
+
+pub(crate) fn mark_flush_success(table_oid: i64) -> anyhow::Result<()> {
+    let args = [DatumWithOid::from(table_oid)];
+    Spi::run_with_args(
+        r#"
+        UPDATE pghouse.tables
+        SET last_flush_at = now()
+        WHERE table_oid = $1::oid
+        "#,
+        &args,
+    )?;
     Ok(())
 }
 

--- a/src/pg/catalog.rs
+++ b/src/pg/catalog.rs
@@ -1,4 +1,5 @@
 use crate::core::interface::{ColumnDescriptor, GranuleRef, TableDescriptor};
+use crate::core::pk::{PkCompareMode, compare_pk_text};
 use anyhow::{Context, Result, anyhow, bail};
 use pgrx::prelude::*;
 use pgrx::spi::{quote_identifier, quote_qualified_identifier};
@@ -18,6 +19,7 @@ pub(crate) struct TableConfig {
     pub(crate) schema_name: String,
     pub(crate) relname: String,
     pub(crate) pk_column: String,
+    pub(crate) pk_compare: PkCompareMode,
     pub(crate) granule_rows: i32,
     pub(crate) compression: String,
     pub(crate) storage_root: String,
@@ -61,6 +63,7 @@ impl From<&TableConfig> for TableDescriptor {
             schema_name: value.schema_name.clone(),
             table_name: value.relname.clone(),
             pk_column: value.pk_column.clone(),
+            pk_compare: value.pk_compare,
             granule_rows: usize::try_from(value.granule_rows.max(1)).unwrap_or(1),
             compression: value.compression.clone(),
             storage_root: value.storage_root.clone(),
@@ -76,6 +79,7 @@ pgrx::extension_sql!(
         table_oid oid PRIMARY KEY,
         table_name regclass NOT NULL UNIQUE,
         pk_column name NOT NULL,
+        pk_compare text NOT NULL CHECK (pk_compare IN ('lexical', 'i64')),
         granule_rows integer NOT NULL CHECK (granule_rows > 0),
         compression text NOT NULL CHECK (compression IN ('zstd')),
         storage_root text NOT NULL,
@@ -257,6 +261,7 @@ pub(crate) fn relation_identity(table_name: &str) -> anyhow::Result<RelationIden
 pub(crate) fn upsert_table_config(
     identity: &RelationIdentity,
     pk_column: &str,
+    pk_compare: PkCompareMode,
     granule_rows: i32,
     compression: &str,
     storage_root: &str,
@@ -268,6 +273,7 @@ pub(crate) fn upsert_table_config(
         DatumWithOid::from(identity.table_oid),
         DatumWithOid::from(identity.table_oid),
         DatumWithOid::from(pk_column),
+        DatumWithOid::from(pk_compare.as_sql_label()),
         DatumWithOid::from(granule_rows),
         DatumWithOid::from(compression),
         DatumWithOid::from(storage_root),
@@ -282,6 +288,7 @@ pub(crate) fn upsert_table_config(
             table_oid,
             table_name,
             pk_column,
+            pk_compare,
             granule_rows,
             compression,
             storage_root,
@@ -298,11 +305,13 @@ pub(crate) fn upsert_table_config(
             $6,
             $7,
             $8,
-            $9
+            $9,
+            $10
         )
         ON CONFLICT (table_oid)
         DO UPDATE SET
             pk_column = EXCLUDED.pk_column,
+            pk_compare = EXCLUDED.pk_compare,
             granule_rows = EXCLUDED.granule_rows,
             compression = EXCLUDED.compression,
             storage_root = EXCLUDED.storage_root,
@@ -392,6 +401,7 @@ pub(crate) fn load_table_config(table_oid: i64) -> anyhow::Result<TableConfig> {
                 n.nspname::text AS schema_name,
                 c.relname::text AS relname,
                 t.pk_column::text AS pk_column,
+                t.pk_compare::text AS pk_compare,
                 t.granule_rows AS granule_rows,
                 t.compression::text AS compression,
                 t.storage_root::text AS storage_root,
@@ -417,6 +427,9 @@ pub(crate) fn load_table_config(table_oid: i64) -> anyhow::Result<TableConfig> {
                 pk_column: row
                     .get_by_name::<String, _>("pk_column")?
                     .unwrap_or_default(),
+                pk_compare: PkCompareMode::from_sql_label(
+                    &row.get_by_name::<String, _>("pk_compare")?.unwrap_or_default(),
+                ),
                 granule_rows: row
                     .get_by_name::<i32, _>("granule_rows")?
                     .unwrap_or_default(),
@@ -486,6 +499,30 @@ pub(crate) fn load_candidate_tables(max_tables: i32) -> anyhow::Result<Vec<i64>>
     Ok(table_oids)
 }
 
+pub(crate) fn try_acquire_table_maintenance_lock(table_oid: i64) -> anyhow::Result<bool> {
+    let args = [DatumWithOid::from(table_oid)];
+    Ok(Spi::get_one_with_args::<bool>(
+        "SELECT pg_try_advisory_lock($1::bigint)",
+        &args,
+    )?
+    .unwrap_or(false))
+}
+
+pub(crate) fn release_table_maintenance_lock(table_oid: i64) -> anyhow::Result<()> {
+    let args = [DatumWithOid::from(table_oid)];
+    let released = Spi::get_one_with_args::<bool>(
+        "SELECT pg_advisory_unlock($1::bigint)",
+        &args,
+    )?
+    .unwrap_or(false);
+
+    if !released {
+        bail!("failed to release maintenance lock for table oid {table_oid}");
+    }
+
+    Ok(())
+}
+
 pub(crate) fn load_pending_rows(
     table_oid: i64,
     limit: i32,
@@ -526,17 +563,19 @@ pub(crate) fn load_pending_rows(
     Ok(pending_rows)
 }
 
-pub(crate) fn load_live_rows(table_oid: i64) -> anyhow::Result<Vec<LiveRow>> {
+pub(crate) fn load_live_rows(
+    table_oid: i64,
+    pk_compare: PkCompareMode,
+) -> anyhow::Result<Vec<LiveRow>> {
     let args = [DatumWithOid::from(table_oid)];
 
-    let live_rows = Spi::connect(|client| -> Result<Vec<LiveRow>, spi::Error> {
+    let mut live_rows = Spi::connect(|client| -> Result<Vec<LiveRow>, spi::Error> {
         let rows = client.select(
             r#"
             SELECT pk_text::text AS pk_text, row_json::text AS row_json
             FROM pghouse.row_versions
             WHERE table_oid = $1::oid
               AND NOT deleted
-            ORDER BY pk_text
             "#,
             None,
             &args,
@@ -553,7 +592,33 @@ pub(crate) fn load_live_rows(table_oid: i64) -> anyhow::Result<Vec<LiveRow>> {
         Ok(live)
     })?;
 
+    live_rows.sort_by(|left, right| compare_pk_text(pk_compare, &left.pk_text, &right.pk_text));
     Ok(live_rows)
+}
+
+pub(crate) fn resolve_pk_compare_mode(
+    table_oid: i64,
+    pk_column: &str,
+) -> anyhow::Result<PkCompareMode> {
+    let args = [DatumWithOid::from(table_oid), DatumWithOid::from(pk_column)];
+    let typname = Spi::get_one_with_args::<String>(
+        r#"
+        SELECT t.typname::text
+        FROM pg_attribute a
+        JOIN pg_type t ON t.oid = a.atttypid
+        WHERE a.attrelid = $1::oid
+          AND a.attname = $2::name
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        "#,
+        &args,
+    )?
+    .ok_or_else(|| anyhow!("PK column {pk_column} does not exist on table oid {table_oid}"))?;
+
+    Ok(match typname.as_str() {
+        "int2" | "int4" | "int8" | "oid" => PkCompareMode::I64,
+        _ => PkCompareMode::Lexical,
+    })
 }
 
 pub(crate) fn load_column_specs(table_oid: i64) -> anyhow::Result<Vec<ColumnSpec>> {

--- a/src/pg/scan.rs
+++ b/src/pg/scan.rs
@@ -1,12 +1,14 @@
 use crate::core::codec::JsonArrayZstdCodec;
-use crate::core::file_layout::read_json_file;
+use crate::core::file_layout::{read_json_file, read_json_lines};
 use crate::core::interface::{
     ChunkCodec, ColumnDescriptor, ColumnVector, EncodedColumnChunk, GranuleManifest, GranuleReader,
     GranuleRef, ScanBatch, ScanPlan, ScanPlanner, ScanRequest,
 };
-use crate::core::scan::{build_scan_plan, materialize_rows};
-use crate::pg::catalog::load_scan_granules;
+use crate::core::scan::{MaterializedRow, build_scan_plan, materialize_row_entries};
+use crate::pg::catalog::{load_scan_granules, load_visible_insert_buffers};
 use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -94,16 +96,21 @@ pub(crate) fn execute_scan(plan: &ScanPlan) -> Result<Vec<serde_json::Value>> {
     for granule in &plan.granules {
         batches.push(reader.read_granule(plan, granule)?);
     }
-    materialize_rows(plan, &batches)
+
+    let mut rows = materialize_row_entries(plan, &batches)?;
+    rows.extend(load_buffered_rows(plan)?);
+    rows.sort_by(|left, right| left.pk_text.cmp(&right.pk_text));
+
+    if let Some(limit) = plan.limit {
+        rows.truncate(limit);
+    }
+
+    Ok(rows.into_iter().map(|row| row.row).collect())
 }
 
 fn required_columns(plan: &ScanPlan) -> Vec<ColumnDescriptor> {
     let mut columns = plan.projection.clone();
-    if (plan.pk_min.is_some() || plan.pk_max.is_some())
-        && !columns
-            .iter()
-            .any(|column| column.name == plan.table.pk_column)
-    {
+    if !columns.iter().any(|column| column.name == plan.table.pk_column) {
         columns.push(ColumnDescriptor {
             ordinal: 0,
             name: plan.table.pk_column.clone(),
@@ -124,4 +131,62 @@ fn load_granule_manifest(plan: &ScanPlan, granule: &GranuleRef) -> Result<Granul
         );
     }
     Ok(manifest)
+}
+
+#[derive(Debug, Deserialize)]
+struct BufferedInsertRecord {
+    pk_text: String,
+    row_json: Value,
+}
+
+fn load_buffered_rows(plan: &ScanPlan) -> Result<Vec<MaterializedRow>> {
+    let buffers = load_visible_insert_buffers(plan.table.table_oid)?;
+    let mut rows = Vec::new();
+
+    for buffer in buffers {
+        let path = PathBuf::from(&plan.table.storage_root).join(&buffer.storage_path);
+        let staged_rows = read_json_lines::<BufferedInsertRecord>(&path)
+            .with_context(|| format!("failed to read insert buffer {}", path.display()))?;
+        for staged_row in staged_rows {
+            if !pk_matches_bounds(
+                &staged_row.pk_text,
+                plan.pk_min.as_deref(),
+                plan.pk_max.as_deref(),
+            ) {
+                continue;
+            }
+            rows.push(MaterializedRow {
+                pk_text: Some(staged_row.pk_text),
+                row: project_row(&staged_row.row_json, &plan.projection),
+            });
+        }
+    }
+
+    Ok(rows)
+}
+
+fn project_row(row_json: &Value, projection: &[ColumnDescriptor]) -> Value {
+    match row_json {
+        Value::Object(object) => {
+            let mut projected = Map::with_capacity(projection.len());
+            for column in projection {
+                let value = object.get(&column.name).cloned().unwrap_or(Value::Null);
+                projected.insert(column.name.clone(), value);
+            }
+            Value::Object(projected)
+        }
+        _ => Value::Object(Map::new()),
+    }
+}
+
+fn pk_matches_bounds(value: &str, pk_min: Option<&str>, pk_max: Option<&str>) -> bool {
+    if pk_min.is_some_and(|bound| value < bound) {
+        return false;
+    }
+
+    if pk_max.is_some_and(|bound| value > bound) {
+        return false;
+    }
+
+    true
 }

--- a/src/pg/scan.rs
+++ b/src/pg/scan.rs
@@ -4,6 +4,7 @@ use crate::core::interface::{
     ChunkCodec, ColumnDescriptor, ColumnVector, EncodedColumnChunk, GranuleManifest, GranuleReader,
     GranuleRef, ScanBatch, ScanPlan, ScanPlanner, ScanRequest,
 };
+use crate::core::pk::{compare_optional_pk_text, pk_matches_bounds};
 use crate::core::scan::{MaterializedRow, build_scan_plan, materialize_row_entries};
 use crate::pg::catalog::{load_scan_granules, load_visible_insert_buffers};
 use anyhow::{Context, Result, anyhow, bail};
@@ -97,15 +98,42 @@ pub(crate) fn execute_scan(plan: &ScanPlan) -> Result<Vec<serde_json::Value>> {
         batches.push(reader.read_granule(plan, granule)?);
     }
 
-    let mut rows = materialize_row_entries(plan, &batches)?;
-    rows.extend(load_buffered_rows(plan)?);
-    rows.sort_by(|left, right| left.pk_text.cmp(&right.pk_text));
+    let rows = materialize_row_entries(plan, &batches)?;
+    let buffered_rows = load_buffered_rows(plan)?;
+    let mut rows = deduplicate_visible_rows(rows, buffered_rows);
+    rows.sort_by(|left, right| {
+        compare_optional_pk_text(
+            plan.table.pk_compare,
+            left.pk_text.as_deref(),
+            right.pk_text.as_deref(),
+        )
+    });
 
     if let Some(limit) = plan.limit {
         rows.truncate(limit);
     }
 
     Ok(rows.into_iter().map(|row| row.row).collect())
+}
+
+fn deduplicate_visible_rows(
+    granule_rows: Vec<MaterializedRow>,
+    buffered_rows: Vec<MaterializedRow>,
+) -> Vec<MaterializedRow> {
+    let mut deduped = std::collections::BTreeMap::new();
+    let mut rows_without_pk = Vec::new();
+
+    for row in granule_rows.into_iter().chain(buffered_rows) {
+        if let Some(pk_text) = row.pk_text.clone() {
+            deduped.insert(pk_text, row);
+        } else {
+            rows_without_pk.push(row);
+        }
+    }
+
+    let mut rows = deduped.into_values().collect::<Vec<_>>();
+    rows.extend(rows_without_pk);
+    rows
 }
 
 fn required_columns(plan: &ScanPlan) -> Vec<ColumnDescriptor> {
@@ -149,7 +177,8 @@ fn load_buffered_rows(plan: &ScanPlan) -> Result<Vec<MaterializedRow>> {
             .with_context(|| format!("failed to read insert buffer {}", path.display()))?;
         for staged_row in staged_rows {
             if !pk_matches_bounds(
-                &staged_row.pk_text,
+                plan.table.pk_compare,
+                Some(&staged_row.pk_text),
                 plan.pk_min.as_deref(),
                 plan.pk_max.as_deref(),
             ) {
@@ -179,14 +208,40 @@ fn project_row(row_json: &Value, projection: &[ColumnDescriptor]) -> Value {
     }
 }
 
-fn pk_matches_bounds(value: &str, pk_min: Option<&str>, pk_max: Option<&str>) -> bool {
-    if pk_min.is_some_and(|bound| value < bound) {
-        return false;
-    }
+#[cfg(test)]
+mod tests {
+    use super::deduplicate_visible_rows;
+    use crate::core::scan::MaterializedRow;
+    use serde_json::json;
 
-    if pk_max.is_some_and(|bound| value > bound) {
-        return false;
-    }
+    #[test]
+    fn buffered_rows_replace_duplicate_granule_rows() {
+        let rows = deduplicate_visible_rows(
+            vec![
+                MaterializedRow {
+                    pk_text: Some("1".to_string()),
+                    row: json!({"id": 1, "payload": "granule"}),
+                },
+                MaterializedRow {
+                    pk_text: Some("2".to_string()),
+                    row: json!({"id": 2, "payload": "granule"}),
+                },
+            ],
+            vec![
+                MaterializedRow {
+                    pk_text: Some("2".to_string()),
+                    row: json!({"id": 2, "payload": "buffer"}),
+                },
+                MaterializedRow {
+                    pk_text: Some("3".to_string()),
+                    row: json!({"id": 3, "payload": "buffer"}),
+                },
+            ],
+        );
 
-    true
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().any(|row| row.row == json!({"id": 1, "payload": "granule"})));
+        assert!(rows.iter().any(|row| row.row == json!({"id": 2, "payload": "buffer"})));
+        assert!(rows.iter().any(|row| row.row == json!({"id": 3, "payload": "buffer"})));
+    }
 }

--- a/src/pg/storage.rs
+++ b/src/pg/storage.rs
@@ -19,101 +19,18 @@ pub(crate) struct FileSnapshotWriter;
 
 impl SnapshotWriter for FileSnapshotWriter {
     fn replace_snapshot(&self, request: &GranuleWriteRequest) -> Result<GranuleWriteResult> {
-        let table_root = PathBuf::from(&request.table.storage_root);
-        fs::create_dir_all(&table_root).with_context(|| {
-            format!(
-                "failed to create table storage root {}",
-                table_root.display()
-            )
-        })?;
-
-        let first_generation = request
-            .granules
-            .first()
-            .map(|granule| granule.span.generation);
-
-        if request.granules.is_empty() {
-            cleanup_generation_dirs(&table_root, None)?;
-            delete_all_granules(request.table.table_oid)?;
-            mark_merge_success(request.table.table_oid)?;
-            return Ok(GranuleWriteResult {
-                granules_written: 0,
-                rows_written: 0,
-                first_generation: None,
-            });
-        }
-
-        for granule in &request.granules {
-            let granule_dir = table_root.join(format!("g{:020}", granule.span.generation));
-            if granule_dir.exists() {
-                fs::remove_dir_all(&granule_dir).with_context(|| {
-                    format!(
-                        "failed to clear granule directory {}",
-                        granule_dir.display()
-                    )
-                })?;
-            }
-            fs::create_dir_all(&granule_dir).with_context(|| {
-                format!(
-                    "failed to create granule directory {}",
-                    granule_dir.display()
-                )
-            })?;
-
-            let mut manifest = GranuleManifest {
-                table_oid: request.table.table_oid,
-                generation: granule.span.generation,
-                row_count: granule.span.row_count,
-                pk_min: granule.span.pk_min.clone(),
-                pk_max: granule.span.pk_max.clone(),
-                chunks: Vec::with_capacity(granule.chunks.len()),
-            };
-            for chunk in &granule.chunks {
-                let relative_path = chunk_relative_path(
-                    granule.span.generation,
-                    chunk.column.ordinal,
-                    &chunk.column.name,
-                    &chunk.codec,
-                );
-                let absolute_path = table_root.join(&relative_path);
-                write_chunk_file(&absolute_path, &chunk.payload)?;
-                manifest.chunks.push(ChunkManifestEntry {
-                    column: chunk.column.clone(),
-                    codec: chunk.codec.clone(),
-                    row_count: chunk.row_count,
-                    uncompressed_bytes: chunk.uncompressed_bytes,
-                    compressed_bytes: chunk.compressed_bytes,
-                    storage_path: relative_path.to_string_lossy().into_owned(),
-                });
-            }
-
-            let manifest_relative_path = manifest_relative_path(granule.span.generation);
-            let manifest_absolute_path = table_root.join(&manifest_relative_path);
-            write_json_file(&manifest_absolute_path, &manifest)?;
-            insert_granule(
-                request.table.table_oid,
-                granule.span.generation,
-                granule.span.row_count,
-                granule.span.pk_min.as_deref(),
-                granule.span.pk_max.as_deref(),
-                &manifest_relative_path.to_string_lossy(),
-            )?;
-        }
-
-        cleanup_generation_dirs(&table_root, first_generation)?;
-        delete_stale_granules(request.table.table_oid, first_generation)?;
+        let result = write_granules(request, WriteMode::Replace)?;
         mark_merge_success(request.table.table_oid)?;
-
-        Ok(GranuleWriteResult {
-            granules_written: request.granules.len(),
-            rows_written: request
-                .granules
-                .iter()
-                .map(|granule| usize::try_from(granule.span.row_count.max(0)).unwrap_or_default())
-                .sum(),
-            first_generation,
-        })
+        Ok(result)
     }
+}
+
+pub(crate) fn append_granules(request: &GranuleWriteRequest) -> Result<GranuleWriteResult> {
+    write_granules(request, WriteMode::Append)
+}
+
+pub(crate) fn insert_buffer_absolute_path(storage_root: &str, storage_path: &str) -> PathBuf {
+    PathBuf::from(storage_root).join(storage_path)
 }
 
 pub(crate) fn resolve_storage_root(table_oid: i64, requested_path: &str) -> Result<String> {
@@ -135,6 +52,110 @@ pub(crate) fn resolve_storage_root(table_oid: i64, requested_path: &str) -> Resu
 
 pub(crate) fn reset_table_storage(storage_root: &str) -> Result<()> {
     reset_storage_root(storage_root)
+}
+
+enum WriteMode {
+    Replace,
+    Append,
+}
+
+fn write_granules(request: &GranuleWriteRequest, mode: WriteMode) -> Result<GranuleWriteResult> {
+    let table_root = PathBuf::from(&request.table.storage_root);
+    fs::create_dir_all(&table_root).with_context(|| {
+        format!(
+            "failed to create table storage root {}",
+            table_root.display()
+        )
+    })?;
+
+    let first_generation = request
+        .granules
+        .first()
+        .map(|granule| granule.span.generation);
+
+    if request.granules.is_empty() {
+        if matches!(mode, WriteMode::Replace) {
+            cleanup_generation_dirs(&table_root, None)?;
+            delete_all_granules(request.table.table_oid)?;
+        }
+        return Ok(GranuleWriteResult {
+            granules_written: 0,
+            rows_written: 0,
+            first_generation: None,
+        });
+    }
+
+    for granule in &request.granules {
+        let granule_dir = table_root.join(format!("g{:020}", granule.span.generation));
+        if granule_dir.exists() {
+            fs::remove_dir_all(&granule_dir).with_context(|| {
+                format!(
+                    "failed to clear granule directory {}",
+                    granule_dir.display()
+                )
+            })?;
+        }
+        fs::create_dir_all(&granule_dir).with_context(|| {
+            format!(
+                "failed to create granule directory {}",
+                granule_dir.display()
+            )
+        })?;
+
+        let mut manifest = GranuleManifest {
+            table_oid: request.table.table_oid,
+            generation: granule.span.generation,
+            row_count: granule.span.row_count,
+            pk_min: granule.span.pk_min.clone(),
+            pk_max: granule.span.pk_max.clone(),
+            chunks: Vec::with_capacity(granule.chunks.len()),
+        };
+        for chunk in &granule.chunks {
+            let relative_path = chunk_relative_path(
+                granule.span.generation,
+                chunk.column.ordinal,
+                &chunk.column.name,
+                &chunk.codec,
+            );
+            let absolute_path = table_root.join(&relative_path);
+            write_chunk_file(&absolute_path, &chunk.payload)?;
+            manifest.chunks.push(ChunkManifestEntry {
+                column: chunk.column.clone(),
+                codec: chunk.codec.clone(),
+                row_count: chunk.row_count,
+                uncompressed_bytes: chunk.uncompressed_bytes,
+                compressed_bytes: chunk.compressed_bytes,
+                storage_path: relative_path.to_string_lossy().into_owned(),
+            });
+        }
+
+        let manifest_relative_path = manifest_relative_path(granule.span.generation);
+        let manifest_absolute_path = table_root.join(&manifest_relative_path);
+        write_json_file(&manifest_absolute_path, &manifest)?;
+        insert_granule(
+            request.table.table_oid,
+            granule.span.generation,
+            granule.span.row_count,
+            granule.span.pk_min.as_deref(),
+            granule.span.pk_max.as_deref(),
+            &manifest_relative_path.to_string_lossy(),
+        )?;
+    }
+
+    if matches!(mode, WriteMode::Replace) {
+        cleanup_generation_dirs(&table_root, first_generation)?;
+        delete_stale_granules(request.table.table_oid, first_generation)?;
+    }
+
+    Ok(GranuleWriteResult {
+        granules_written: request.granules.len(),
+        rows_written: request
+            .granules
+            .iter()
+            .map(|granule| usize::try_from(granule.span.row_count.max(0)).unwrap_or_default())
+            .sum(),
+        first_generation,
+    })
 }
 
 fn default_storage_base_path() -> Result<PathBuf> {

--- a/src/pg/worker.rs
+++ b/src/pg/worker.rs
@@ -1,12 +1,14 @@
 use crate::core::codec::JsonArrayZstdCodec;
 use crate::core::file_layout::read_json_lines;
 use crate::core::interface::{ColumnDescriptor, RowVersion, SnapshotWriter};
+use crate::core::pk::compare_pk_text;
 use crate::core::snapshot::build_snapshot_write_request;
 use crate::pg::catalog::{
     InsertBuffer, TableConfig, apply_mutation, claim_ready_insert_buffers, dirty_row_count,
     load_candidate_tables, load_column_specs, load_live_rows, load_pending_rows, load_table_config,
     mark_flush_success, mark_insert_buffer_flushed, mark_merge_failure, next_generation,
-    pending_merge_count, release_insert_buffer_claim, upsert_buffered_row_version,
+    pending_merge_count, release_insert_buffer_claim, release_table_maintenance_lock,
+    try_acquire_table_maintenance_lock, upsert_buffered_row_version,
 };
 use crate::pg::storage::{FileSnapshotWriter, append_granules, insert_buffer_absolute_path};
 use anyhow::{Context, Result};
@@ -59,6 +61,22 @@ pub(crate) fn run_maintenance_cycle(
 }
 
 fn maintain_table(table_oid: i64, pending_limit: i32) -> Result<MaintenanceStats> {
+    if !try_acquire_table_maintenance_lock(table_oid)? {
+        return Ok(MaintenanceStats::default());
+    }
+
+    let result = maintain_table_locked(table_oid, pending_limit);
+    let unlock_result = release_table_maintenance_lock(table_oid);
+
+    match (result, unlock_result) {
+        (Ok(stats), Ok(())) => Ok(stats),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(_)) => Err(error),
+    }
+}
+
+fn maintain_table_locked(table_oid: i64, pending_limit: i32) -> Result<MaintenanceStats> {
     let config = load_table_config(table_oid)?;
 
     let mut stats = MaintenanceStats::default();
@@ -127,7 +145,6 @@ fn flush_insert_buffers(config: &TableConfig) -> Result<FlushStats> {
             &mut next_generation_value,
         ) {
             Ok(result) => {
-                mark_insert_buffer_flushed(buffer.id)?;
                 mark_flush_success(config.table_oid)?;
                 stats.rows_flushed += result.rows_flushed;
                 stats.granules_written += result.granules_written;
@@ -159,10 +176,17 @@ fn flush_single_insert_buffer(
     let absolute_path = insert_buffer_absolute_path(&config.storage_root, &buffer.storage_path);
     let mut rows = read_json_lines::<BufferedInsertRecord>(&absolute_path)?;
     if rows.is_empty() {
+        mark_insert_buffer_flushed(buffer.id)?;
+        fs::remove_file(&absolute_path).with_context(|| {
+            format!(
+                "failed to remove empty flushed insert buffer file {}",
+                absolute_path.display()
+            )
+        })?;
         return Ok(SingleBufferFlushResult::default());
     }
 
-    rows.sort_by(|left, right| left.pk_text.cmp(&right.pk_text));
+    rows.sort_by(|left, right| compare_pk_text(table.pk_compare, &left.pk_text, &right.pk_text));
 
     let mut row_versions = Vec::with_capacity(rows.len());
     for row in &rows {
@@ -188,6 +212,7 @@ fn flush_single_insert_buffer(
     )?;
     let result = append_granules(&request)?;
     *next_generation_value += i64::try_from(result.granules_written).unwrap_or_default();
+    mark_insert_buffer_flushed(buffer.id)?;
     fs::remove_file(&absolute_path).with_context(|| {
         format!(
             "failed to remove flushed insert buffer file {}",
@@ -202,7 +227,7 @@ fn flush_single_insert_buffer(
 }
 
 fn rewrite_table_snapshot(config: &TableConfig) -> Result<usize> {
-    let live_rows = load_live_rows(config.table_oid)?;
+    let live_rows = load_live_rows(config.table_oid, config.pk_compare)?;
     let columns = load_column_specs(config.table_oid)?;
     let base_generation = next_generation(config.table_oid)?;
     let table = crate::core::interface::TableDescriptor::from(config);

--- a/src/pg/worker.rs
+++ b/src/pg/worker.rs
@@ -1,23 +1,28 @@
 use crate::core::codec::JsonArrayZstdCodec;
+use crate::core::file_layout::read_json_lines;
 use crate::core::interface::{ColumnDescriptor, RowVersion, SnapshotWriter};
 use crate::core::snapshot::build_snapshot_write_request;
 use crate::pg::catalog::{
-    TableConfig, apply_mutation, dirty_row_count, load_candidate_tables, load_column_specs,
-    load_live_rows, load_pending_rows, load_table_config, mark_merge_failure, next_generation,
-    pending_merge_count,
+    InsertBuffer, TableConfig, apply_mutation, claim_ready_insert_buffers, dirty_row_count,
+    load_candidate_tables, load_column_specs, load_live_rows, load_pending_rows, load_table_config,
+    mark_flush_success, mark_insert_buffer_flushed, mark_merge_failure, next_generation,
+    pending_merge_count, release_insert_buffer_claim, upsert_buffered_row_version,
 };
-use crate::pg::storage::FileSnapshotWriter;
+use crate::pg::storage::{FileSnapshotWriter, append_granules, insert_buffer_absolute_path};
 use anyhow::{Context, Result};
 use pgrx::bgworkers::{BackgroundWorker, BackgroundWorkerBuilder, SignalWakeFlags};
 use pgrx::prelude::*;
 use pgrx::{JsonB, pg_guard, pg_sys, warning};
 use serde::Serialize;
 use serde_json::Value;
+use std::fs;
 use std::time::Duration;
 
 #[derive(Debug, Default, Serialize)]
 pub(crate) struct MaintenanceStats {
     pub(crate) tables_scanned: usize,
+    pub(crate) buffered_rows_flushed: usize,
+    pub(crate) granules_appended: usize,
     pub(crate) pending_rows_applied: usize,
     pub(crate) merges_completed: usize,
     pub(crate) live_rows_rewritten: usize,
@@ -34,6 +39,8 @@ pub(crate) fn run_maintenance_cycle(
 
         match maintain_table(table_oid, pending_limit) {
             Ok(table_stats) => {
+                stats.buffered_rows_flushed += table_stats.buffered_rows_flushed;
+                stats.granules_appended += table_stats.granules_appended;
                 stats.pending_rows_applied += table_stats.pending_rows_applied;
                 stats.merges_completed += table_stats.merges_completed;
                 stats.live_rows_rewritten += table_stats.live_rows_rewritten;
@@ -53,9 +60,13 @@ pub(crate) fn run_maintenance_cycle(
 
 fn maintain_table(table_oid: i64, pending_limit: i32) -> Result<MaintenanceStats> {
     let config = load_table_config(table_oid)?;
-    let pending_rows = load_pending_rows(table_oid, pending_limit)?;
 
     let mut stats = MaintenanceStats::default();
+    let flushed = flush_insert_buffers(&config)?;
+    stats.buffered_rows_flushed = flushed.rows_flushed;
+    stats.granules_appended = flushed.granules_written;
+
+    let pending_rows = load_pending_rows(table_oid, pending_limit)?;
     for mutation in &pending_rows {
         apply_mutation(mutation, table_oid)?;
     }
@@ -73,6 +84,121 @@ fn maintain_table(table_oid: i64, pending_limit: i32) -> Result<MaintenanceStats
     }
 
     Ok(stats)
+}
+
+#[derive(Debug, Default)]
+struct FlushStats {
+    rows_flushed: usize,
+    granules_written: usize,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct BufferedInsertRecord {
+    pk_text: String,
+    row_json: Value,
+}
+
+fn flush_insert_buffers(config: &TableConfig) -> Result<FlushStats> {
+    let claimed_buffers = claim_ready_insert_buffers(config.table_oid, 64)?;
+    if claimed_buffers.is_empty() {
+        return Ok(FlushStats::default());
+    }
+
+    let columns = load_column_specs(config.table_oid)?;
+    let column_descriptors = columns
+        .iter()
+        .map(|column| ColumnDescriptor {
+            ordinal: column.attnum,
+            name: column.attname.clone(),
+        })
+        .collect::<Vec<_>>();
+    let table = crate::core::interface::TableDescriptor::from(config);
+    let codec = JsonArrayZstdCodec;
+    let mut next_generation_value = next_generation(config.table_oid)?;
+    let mut stats = FlushStats::default();
+
+    for buffer in claimed_buffers {
+        match flush_single_insert_buffer(
+            config,
+            &table,
+            &column_descriptors,
+            &codec,
+            &buffer,
+            &mut next_generation_value,
+        ) {
+            Ok(result) => {
+                mark_insert_buffer_flushed(buffer.id)?;
+                mark_flush_success(config.table_oid)?;
+                stats.rows_flushed += result.rows_flushed;
+                stats.granules_written += result.granules_written;
+            }
+            Err(error) => {
+                let _ = release_insert_buffer_claim(buffer.id);
+                return Err(error);
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+#[derive(Debug, Default)]
+struct SingleBufferFlushResult {
+    rows_flushed: usize,
+    granules_written: usize,
+}
+
+fn flush_single_insert_buffer(
+    config: &TableConfig,
+    table: &crate::core::interface::TableDescriptor,
+    columns: &[ColumnDescriptor],
+    codec: &JsonArrayZstdCodec,
+    buffer: &InsertBuffer,
+    next_generation_value: &mut i64,
+) -> Result<SingleBufferFlushResult> {
+    let absolute_path = insert_buffer_absolute_path(&config.storage_root, &buffer.storage_path);
+    let mut rows = read_json_lines::<BufferedInsertRecord>(&absolute_path)?;
+    if rows.is_empty() {
+        return Ok(SingleBufferFlushResult::default());
+    }
+
+    rows.sort_by(|left, right| left.pk_text.cmp(&right.pk_text));
+
+    let mut row_versions = Vec::with_capacity(rows.len());
+    for row in &rows {
+        upsert_buffered_row_version(
+            config.table_oid,
+            &row.pk_text,
+            &serde_json::to_string(&row.row_json)
+                .with_context(|| format!("failed to serialize buffered row {}", row.pk_text))?,
+        )?;
+        row_versions.push(RowVersion {
+            pk_text: row.pk_text.clone(),
+            row_json: row.row_json.clone(),
+        });
+    }
+
+    let request = build_snapshot_write_request(
+        table.clone(),
+        columns,
+        &row_versions,
+        *next_generation_value,
+        "buffer_flush",
+        codec,
+    )?;
+    let result = append_granules(&request)?;
+    *next_generation_value += i64::try_from(result.granules_written).unwrap_or_default();
+    fs::remove_file(&absolute_path).with_context(|| {
+        format!(
+            "failed to remove flushed insert buffer file {}",
+            absolute_path.display()
+        )
+    })?;
+
+    Ok(SingleBufferFlushResult {
+        rows_flushed: row_versions.len(),
+        granules_written: result.granules_written,
+    })
 }
 
 fn rewrite_table_snapshot(config: &TableConfig) -> Result<usize> {

--- a/src/pg/worker.rs
+++ b/src/pg/worker.rs
@@ -135,13 +135,13 @@ fn flush_insert_buffers(config: &TableConfig) -> Result<FlushStats> {
     let mut next_generation_value = next_generation(config.table_oid)?;
     let mut stats = FlushStats::default();
 
-    for buffer in claimed_buffers {
+    for (index, buffer) in claimed_buffers.iter().enumerate() {
         match flush_single_insert_buffer(
             config,
             &table,
             &column_descriptors,
             &codec,
-            &buffer,
+            buffer,
             &mut next_generation_value,
         ) {
             Ok(result) => {
@@ -151,6 +151,9 @@ fn flush_insert_buffers(config: &TableConfig) -> Result<FlushStats> {
             }
             Err(error) => {
                 let _ = release_insert_buffer_claim(buffer.id);
+                for remaining in claimed_buffers.iter().skip(index + 1) {
+                    let _ = release_insert_buffer_claim(remaining.id);
+                }
                 return Err(error);
             }
         }


### PR DESCRIPTION
resolved: #8

- insert를 즉시 granule로 쓰지 않고 file-backed insert buffer에 먼저 적재
- insert_buffers 메타테이블과 incoming jsonl spool file 경로 추가
- row/byte/timeout 기준으로 insert buffer를 seal하고 granule로 flush
- flush된 row를 row_versions에 반영해 이후 merge snapshot 재작성과 연결
- sidecar scan이 committed granule과 unflushed insert buffer를 함께 읽도록 확장
- INTERNAL.md에 insert buffer 기반 write/read 흐름 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * INSERT용 파일 기반 삽입 버퍼 및 pghouse_stage_insert 스테이징 API 추가
  * 테이블 등록 시 insert_buffer_rows/bytes/flush_ms 파라미터 노출

* **개선**
  * 스캔에서 미플러시된 삽입을 병합·중복제거·PK 정렬해 결과에 반영
  * 삽입 버퍼 주기적 플러시로 소규모 즉시 쓰기 회피 및 성능 개선
  * 유지보수에 버퍼 플러시, granule 추가 통계 및 잠금 기반 동기화 추가

* **문서**
  * 삽입 버퍼 모델, 데이터 흐름 및 extension_sql 사용 가이드 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->